### PR TITLE
Fixed attacking scripts turning off glitch

### DIFF
--- a/2D Platformer/Assets/Scripts/Attacking/PlayerAttack.cs
+++ b/2D Platformer/Assets/Scripts/Attacking/PlayerAttack.cs
@@ -105,7 +105,7 @@ they had beforehand is preserved for when they unfreeze
         body = GetComponentInParent<Rigidbody2D>();
         xKnockbackValue = Math.Abs(knockback[0]);
         hitlag = setHitlag(knockback[0], knockback[1]);
-        power += (int)Math.Ceiling(statSheet.Strength.Value * 1.5);
+        //power += (int)Math.Ceiling(statSheet.Strength.Value * 1.5);
     }
 /*
     Sets up the following for each hitbox in the attack: Damage, Knockback, Hitlag, Visibility


### PR DESCRIPTION
Fixed attack scripts turning off glitch by commenting out the line of code that increased attack power in the Awake() function. If needed, a proper implementation of that line can be done later.